### PR TITLE
fix: stopped cleanup from removing types needed by other candidate types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -114,7 +114,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -141,7 +141,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       
     - name: Install Rust nightly
       uses: dtolnay/rust-toolchain@nightly
@@ -180,7 +180,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -198,7 +198,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -233,7 +233,7 @@ jobs:
       run: cargo llvm-cov --workspace --features z3,skip-expensive-tests --lcov --output-path lcov.info --exclude dotscope-cli
       
     - name: Upload to codecov.io
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v7
       with:
         files: lcov.info
         fail_ci_if_error: true

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -81,7 +81,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         
@@ -122,7 +122,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -68,7 +68,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
@@ -181,7 +181,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -224,7 +224,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -249,7 +249,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-07-16
+
+### Changed
+
+- **Dependencies**: bumped `analyssa` (0.2.0 → 0.3.0), `num-bigint` (0.5.0 → 0.5.1), `tokio` (1.52.3 → 1.52.4), `clap` (4.6.1 → 4.6.2), `anyhow` (1.0.102 → 1.0.103), and `env_logger` in `dotscope-cli` (0.11.10 → 0.11.11, aligning it with the version `dotscope` already used)
+
+This is a patch release: dotscope's own public API is unchanged. `SsaOp` is not re-exported, `conv_op_for_target` is crate-internal, and the analyssa types dotscope *does* re-export (`BinaryOpKind`, `CmpKind`, `UnaryOpKind`, `PhiNode`, `PhiOperand`, `Target`, `PointerSize`, and the loop/symbolic/dataflow types) are all unchanged in analyssa 0.3.0.
+
+Most of analyssa 0.3.0's correctness fixes target native lifters and do not apply to the CIL frontend: the `ld2r`/`setffr`/`dmb` effect corrections concern AArch64/x86 ops dotscope never emits, and the GVN `ComputeFlags`/`CallClobber` fixes concern native flag and call-clobber markers with no CIL equivalent. Likewise the pointer-conversion signedness fix has no observable effect here — dotscope never emits `PtrToInt`, and `CilTarget::convert_const` declines pointer targets, so `IntToPtr` does not constant-fold. What dotscope does inherit is analyssa's structural GVN value key (replacing a per-candidate `Debug`-string key) and the `SsaEditor::nop_instruction` fix that no longer leaves a dead `result_type` on a removed instruction.
+
 ## [0.8.2] - 2026-07-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,13 +99,14 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "analyssa"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345118481d5b39980833d7dcf9ef72f21d0251b090b5233489e36487d3af2bc9"
+checksum = "cf6eaaf643f25047ba272c9bbd3246ca7a75a3f1db908fe98577c325b4ed9ebf"
 dependencies = [
  "boxcar",
  "dashmap",
  "log",
+ "num_enum",
  "rayon",
  "thiserror 2.0.18",
 ]
@@ -227,7 +228,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -265,7 +266,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -402,9 +403,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitmaps"
@@ -494,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -517,22 +518,22 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -549,9 +550,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cached"
@@ -577,7 +578,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -604,7 +605,7 @@ dependencies = [
  "num_cpus",
  "objc2-foundation",
  "objc2-metal",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_distr 0.5.1",
  "rayon",
  "safetensors 0.7.0",
@@ -683,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -701,9 +702,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cfgrammar"
@@ -717,6 +718,17 @@ dependencies = [
  "quote",
  "regex",
  "vob",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -772,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -782,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -802,7 +814,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1037,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1047,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1066,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -1092,7 +1104,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
@@ -1154,7 +1166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1253,7 +1265,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1266,7 +1278,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1288,7 +1300,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1299,7 +1311,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1339,9 +1351,9 @@ checksum = "aafbece59594ed57696a1a69e8bb3ca1683fbc9cdb41d5c02726070b2cd8f19d"
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -1349,15 +1361,14 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1386,7 +1397,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1407,7 +1418,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1417,7 +1428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1438,7 +1449,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1519,7 +1530,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -1533,7 +1544,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1553,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "dotscope"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes",
  "analyssa",
@@ -1579,7 +1590,7 @@ dependencies = [
  "md-5",
  "memmap2",
  "mistralrs",
- "num-bigint 0.5.0",
+ "num-bigint 0.5.1",
  "ouroboros",
  "pbkdf2",
  "quick-xml",
@@ -1598,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "dotscope-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1718,7 +1729,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1761,7 +1772,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1788,14 +1799,16 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "exr"
-version = "1.74.0"
+version = "1.74.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
 dependencies = [
  "bit_field",
  "half",
  "lebe",
  "miniz_oxide",
+ "num-complex",
+ "pulp 0.22.3",
  "rayon-core",
  "smallvec 1.15.2",
  "zune-inflate",
@@ -1874,7 +1887,7 @@ checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_distr 0.5.1",
 ]
 
@@ -1914,7 +1927,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2004,7 +2017,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2346,8 +2359,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2400,7 +2416,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_distr 0.5.1",
  "zerocopy",
 ]
@@ -2484,7 +2500,7 @@ dependencies = [
  "libc",
  "log",
  "num_cpus",
- "rand 0.9.4",
+ "rand 0.9.5",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2516,7 +2532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12d23156ea4dbe6b37ad48fab2da56ff27b0f6192fb5db210c44eb07bfe6e787"
 dependencies = [
  "html5ever 0.38.0",
- "tendril 0.5.0",
+ "tendril 0.5.1",
  "thiserror 2.0.18",
  "unicode-width",
 ]
@@ -2553,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2563,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2925,7 +2941,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2979,9 +2995,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -2993,13 +3009,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3029,7 +3045,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3048,16 +3064,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -3260,7 +3276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "tendril 0.5.0",
+ "tendril 0.5.1",
  "web_atoms",
 ]
 
@@ -3275,9 +3291,9 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -3305,9 +3321,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -3331,7 +3347,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -3407,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -3432,7 +3448,7 @@ dependencies = [
  "indexmap 2.14.0",
  "mistralrs-core",
  "mistralrs-macros",
- "rand 0.9.4",
+ "rand 0.9.5",
  "reqwest 0.13.4",
  "schemars 1.2.1",
  "serde",
@@ -3514,7 +3530,7 @@ dependencies = [
  "ordered-float",
  "parking_lot",
  "radix_trie",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_distr 0.5.1",
  "rand_isaac",
  "rayon",
@@ -3549,7 +3565,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "urlencoding",
- "uuid 1.23.4",
+ "uuid 1.24.0",
  "variantly",
  "vob",
 ]
@@ -3563,7 +3579,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3584,7 +3600,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "utoipa",
- "uuid 1.23.4",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -3664,7 +3680,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3688,7 +3704,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_distr 0.4.3",
  "simba",
  "typenum",
@@ -3715,7 +3731,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3785,7 +3801,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.7",
+ "num-bigint 0.4.8",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -3795,9 +3811,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3805,9 +3821,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7032fbb7ef662c18e806aa75b311f68ddf5c94e8fc62832c0039d79095ab6abf"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3837,7 +3853,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3851,11 +3867,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3866,7 +3881,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.7",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -3889,6 +3904,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3921,7 +3958,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -3938,7 +3975,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -3961,7 +3998,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "objc2",
@@ -3987,7 +4024,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -4028,7 +4065,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
@@ -4075,7 +4112,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4189,7 +4226,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4253,7 +4290,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4315,25 +4352,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-crate"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4353,7 +4377,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -4374,7 +4398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4416,9 +4440,9 @@ checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "qoi"
@@ -4466,15 +4490,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.3",
  "rustls",
@@ -4488,16 +4513,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4533,9 +4558,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4544,12 +4569,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4591,13 +4627,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -4607,7 +4649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -4617,6 +4659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3382fc9f0aad4f2e2a56b53d9133c8c810b4dbf21e7e370e24346161a5b2c7bd"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4655,7 +4706,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -4684,7 +4735,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4751,7 +4802,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4782,7 +4833,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4799,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4997,7 +5048,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5006,9 +5057,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5083,9 +5134,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -5186,7 +5237,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5227,7 +5278,7 @@ checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5236,7 +5287,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5259,7 +5310,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more",
  "log",
@@ -5340,7 +5391,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5351,7 +5402,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5427,7 +5478,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5441,9 +5492,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -5544,15 +5595,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -5599,9 +5650,9 @@ checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5662,7 +5713,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -5743,7 +5794,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5755,7 +5806,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5912,9 +5963,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5938,7 +5989,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5947,7 +5998,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -5975,7 +6026,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -6016,12 +6067,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
- "utf-8",
 ]
 
 [[package]]
@@ -6060,7 +6110,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6071,14 +6121,14 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -6149,9 +6199,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6181,7 +6231,7 @@ dependencies = [
  "macro_rules_attribute",
  "monostate",
  "paste",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "rayon-cond",
  "regex",
@@ -6214,7 +6264,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "rayon-cond",
  "regex",
@@ -6230,13 +6280,13 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.1",
+ "mio 1.2.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -6253,7 +6303,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6337,7 +6387,7 @@ dependencies = [
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
@@ -6353,19 +6403,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -6388,7 +6459,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -6442,7 +6513,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6511,8 +6582,8 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
- "sha1 0.10.6",
+ "rand 0.9.5",
+ "sha1 0.10.7",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -6702,7 +6773,7 @@ checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6716,9 +6787,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6848,7 +6919,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -7066,7 +7137,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7077,7 +7148,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7397,9 +7468,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -7456,7 +7530,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -7468,7 +7542,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -7493,22 +7567,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7528,7 +7602,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -7568,7 +7642,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7585,9 +7659,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"

--- a/dotscope-cli/Cargo.toml
+++ b/dotscope-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotscope-cli"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Johann Kempter <admin@binflip.rs>"]
 edition.workspace = true
 license.workspace = true
@@ -18,12 +18,12 @@ smart-rename = ["dotscope/smart-rename"]
 
 [dependencies]
 dotscope = { path = "../dotscope", features = ["deobfuscation"] }
-clap = { version = "4.6.1", features = ["derive", "env", "wrap_help"] }
+clap = { version = "4.6.2", features = ["derive", "env", "wrap_help"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 comfy-table = "7.2.2"
 widestring = "1.2.1"
 ctrlc = "3.5.2"
-env_logger = "0.11.10"
+env_logger = "0.11.11"
 log = "0.4.33"

--- a/dotscope/Cargo.toml
+++ b/dotscope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotscope"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Johann Kempter <admin@binflip.rs>"]
 edition.workspace = true
 description = "A high-performance, cross-platform framework for analyzing and reverse engineering .NET PE executables"
@@ -66,14 +66,14 @@ rustc-hash = "2.1.3"
 boxcar = "0.2.14"
 quick-xml = "0.41.0"
 hex = "0.4.3"
-num-bigint = { version = "0.5.0", optional = true }
+num-bigint = { version = "0.5.1", optional = true }
 log = "0.4.33"
 flate2 = "1.1.9"
-analyssa = "0.2.0"
+analyssa = "0.3.0"
 lzma-rs = "0.3.0"
 z3 = { version = "0.20.2", optional = true }
 iced-x86 = { version = "1.21.0", default-features = false, features = ["std", "decoder", "instr_info"], optional = true }
-tokio = { version = "1.52.3", optional = true, features = ["rt-multi-thread"] }
+tokio = { version = "1.52.4", optional = true, features = ["rt-multi-thread"] }
 
 # Metal GPU acceleration for LLM inference on macOS (Apple Silicon / AMD GPU).
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -86,7 +86,7 @@ mistralrs = { version = "0.8.1", optional = true }
 [dev-dependencies]
 criterion = "0.8.2"
 env_logger = "0.11.11"
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6.2", features = ["derive"] }
 ctrlc = "3.5.2"
 
 [features]

--- a/dotscope/src/analysis/mod.rs
+++ b/dotscope/src/analysis/mod.rs
@@ -121,6 +121,8 @@ pub use taint::{
 #[cfg(feature = "compiler")]
 #[allow(unused_imports)]
 pub(crate) use cfg::SsaLoopAnalysis;
+#[cfg(feature = "compiler")]
+pub(crate) use ssa::conv_op_for_target;
 
 #[cfg(feature = "x86")]
 pub use x86::{

--- a/dotscope/src/analysis/ssa/builder.rs
+++ b/dotscope/src/analysis/ssa/builder.rs
@@ -37,6 +37,43 @@ use crate::analysis::ssa::{
     SsaBlock, SsaFunction, SsaInstruction, SsaOp, SsaType, SsaVarId, VariableOrigin,
 };
 
+/// Builds the conversion op that produces `target` from `operand`.
+///
+/// A CIL conversion opcode fixes the destination type but not the source (the
+/// evaluation-stack value is untyped at decompose time), so the source domain
+/// defaults to integer: a float target is an integer→float conversion, a
+/// pointer target an integer→pointer conversion, and every other target an
+/// integer→integer conversion. `unsigned` carries the opcode's signedness
+/// (`conv.u*` vs `conv.i*`); `overflow_check` the checked `conv.ovf.*` form.
+pub(crate) fn conv_op_for_target(
+    dest: SsaVarId,
+    operand: SsaVarId,
+    target: SsaType,
+    unsigned: bool,
+    overflow_check: bool,
+) -> SsaOp {
+    match target {
+        SsaType::F32 | SsaType::F64 => SsaOp::IntToFloat {
+            dest,
+            operand,
+            target,
+            unsigned,
+        },
+        SsaType::Pointer(_) | SsaType::ByRef(_) => SsaOp::IntToPtr {
+            dest,
+            operand,
+            target,
+        },
+        _ => SsaOp::IntConv {
+            dest,
+            operand,
+            target,
+            overflow_check,
+            unsigned,
+        },
+    }
+}
+
 /// Builder for constructing SSA functions programmatically.
 ///
 /// Provides a closure-based API for building SSA functions where all
@@ -689,13 +726,7 @@ impl SsaBlockBuilder<'_> {
     #[must_use]
     pub fn conv(&mut self, operand: SsaVarId, target: SsaType) -> SsaVarId {
         let dest = self.builder.alloc_stack_var_typed(target.clone());
-        let op = SsaOp::Conv {
-            dest,
-            operand,
-            target,
-            overflow_check: false,
-            unsigned: false,
-        };
+        let op = conv_op_for_target(dest, operand, target, false, false);
         self.block.add_instruction(SsaInstruction::synthetic(op));
         dest
     }
@@ -704,13 +735,7 @@ impl SsaBlockBuilder<'_> {
     #[must_use]
     pub fn conv_un(&mut self, operand: SsaVarId, target: SsaType) -> SsaVarId {
         let dest = self.builder.alloc_stack_var_typed(target.clone());
-        let op = SsaOp::Conv {
-            dest,
-            operand,
-            target,
-            overflow_check: false,
-            unsigned: true,
-        };
+        let op = conv_op_for_target(dest, operand, target, true, false);
         self.block.add_instruction(SsaInstruction::synthetic(op));
         dest
     }
@@ -719,13 +744,7 @@ impl SsaBlockBuilder<'_> {
     #[must_use]
     pub fn conv_ovf(&mut self, operand: SsaVarId, target: SsaType) -> SsaVarId {
         let dest = self.builder.alloc_stack_var_typed(target.clone());
-        let op = SsaOp::Conv {
-            dest,
-            operand,
-            target,
-            overflow_check: true,
-            unsigned: false,
-        };
+        let op = conv_op_for_target(dest, operand, target, false, true);
         self.block.add_instruction(SsaInstruction::synthetic(op));
         dest
     }
@@ -734,13 +753,7 @@ impl SsaBlockBuilder<'_> {
     #[must_use]
     pub fn conv_ovf_un(&mut self, operand: SsaVarId, target: SsaType) -> SsaVarId {
         let dest = self.builder.alloc_stack_var_typed(target.clone());
-        let op = SsaOp::Conv {
-            dest,
-            operand,
-            target,
-            overflow_check: true,
-            unsigned: true,
-        };
+        let op = conv_op_for_target(dest, operand, target, true, true);
         self.block.add_instruction(SsaInstruction::synthetic(op));
         dest
     }

--- a/dotscope/src/analysis/ssa/converter.rs
+++ b/dotscope/src/analysis/ssa/converter.rs
@@ -335,7 +335,7 @@ impl<'a, 'cfg> SsaConverter<'a, 'cfg> {
             | SsaOp::BoolNot { .. } => SsaType::Bool,
 
             // Conversion - use the target type
-            SsaOp::Conv { target, .. } => target.clone(),
+            SsaOp::IntConv { target, .. } | SsaOp::IntToPtr { target, .. } | SsaOp::PtrToInt { target, .. } | SsaOp::IntToFloat { target, .. } | SsaOp::FloatToInt { target, .. } | SsaOp::FloatConv { target, .. } => target.clone(),
 
             // Arithmetic operations - typically I32 for stack operations
             SsaOp::Add { .. }

--- a/dotscope/src/analysis/ssa/decompose.rs
+++ b/dotscope/src/analysis/ssa/decompose.rs
@@ -28,6 +28,7 @@
 
 use crate::{
     analysis::ssa::{
+        conv_op_for_target,
         ops::{CmpKind, SsaOp},
         types::{FieldRef, MethodRef, SigRef, SsaType, TypeRef},
         value::ConstValue,
@@ -365,271 +366,139 @@ fn decompose_standard_instruction(
             unsigned: true,
             flags: None,
         }),
-        0x67 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x67 => unary_op(uses, def, |dest, operand| {
             // conv.i1
-            dest,
-            operand,
-            target: SsaType::I8,
-            overflow_check: false,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::I8, false, false)
         }),
-        0x68 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x68 => unary_op(uses, def, |dest, operand| {
             // conv.i2
-            dest,
-            operand,
-            target: SsaType::I16,
-            overflow_check: false,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::I16, false, false)
         }),
-        0x69 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x69 => unary_op(uses, def, |dest, operand| {
             // conv.i4
-            dest,
-            operand,
-            target: SsaType::I32,
-            overflow_check: false,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::I32, false, false)
         }),
-        0x6A => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x6A => unary_op(uses, def, |dest, operand| {
             // conv.i8
-            dest,
-            operand,
-            target: SsaType::I64,
-            overflow_check: false,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::I64, false, false)
         }),
-        0x6B => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x6B => unary_op(uses, def, |dest, operand| {
             // conv.r4
-            dest,
-            operand,
-            target: SsaType::F32,
-            overflow_check: false,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::F32, false, false)
         }),
-        0x6C => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x6C => unary_op(uses, def, |dest, operand| {
             // conv.r8
-            dest,
-            operand,
-            target: SsaType::F64,
-            overflow_check: false,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::F64, false, false)
         }),
-        0xD1 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xD1 => unary_op(uses, def, |dest, operand| {
             // conv.u2
-            dest,
-            operand,
-            target: SsaType::U16,
-            overflow_check: false,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::U16, true, false)
         }),
-        0xD2 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xD2 => unary_op(uses, def, |dest, operand| {
             // conv.u1
-            dest,
-            operand,
-            target: SsaType::U8,
-            overflow_check: false,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::U8, true, false)
         }),
-        0x6D => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x6D => unary_op(uses, def, |dest, operand| {
             // conv.u4
-            dest,
-            operand,
-            target: SsaType::U32,
-            overflow_check: false,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::U32, true, false)
         }),
-        0x6E => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x6E => unary_op(uses, def, |dest, operand| {
             // conv.u8
-            dest,
-            operand,
-            target: SsaType::U64,
-            overflow_check: false,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::U64, true, false)
         }),
-        0xD3 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xD3 => unary_op(uses, def, |dest, operand| {
             // conv.i
-            dest,
-            operand,
-            target: SsaType::NativeInt,
-            overflow_check: false,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::NativeInt, false, false)
         }),
-        0xE0 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xE0 => unary_op(uses, def, |dest, operand| {
             // conv.u
-            dest,
-            operand,
-            target: SsaType::NativeUInt,
-            overflow_check: false,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::NativeUInt, true, false)
         }),
-        0x76 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x76 => unary_op(uses, def, |dest, operand| {
             // conv.r.un
-            dest,
-            operand,
-            target: SsaType::F64,
-            overflow_check: false,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::F64, true, false)
         }),
 
         // Overflow-checking conversions
-        0xB3 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xB3 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.i1
-            dest,
-            operand,
-            target: SsaType::I8,
-            overflow_check: true,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::I8, false, true)
         }),
-        0x82 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x82 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.i1.un
-            dest,
-            operand,
-            target: SsaType::I8,
-            overflow_check: true,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::I8, true, true)
         }),
-        0xB5 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xB5 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.i2
-            dest,
-            operand,
-            target: SsaType::I16,
-            overflow_check: true,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::I16, false, true)
         }),
-        0x83 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x83 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.i2.un
-            dest,
-            operand,
-            target: SsaType::I16,
-            overflow_check: true,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::I16, true, true)
         }),
-        0xB7 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xB7 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.i4
-            dest,
-            operand,
-            target: SsaType::I32,
-            overflow_check: true,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::I32, false, true)
         }),
-        0x84 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x84 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.i4.un
-            dest,
-            operand,
-            target: SsaType::I32,
-            overflow_check: true,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::I32, true, true)
         }),
-        0xB9 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xB9 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.i8
-            dest,
-            operand,
-            target: SsaType::I64,
-            overflow_check: true,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::I64, false, true)
         }),
-        0x85 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x85 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.i8.un
-            dest,
-            operand,
-            target: SsaType::I64,
-            overflow_check: true,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::I64, true, true)
         }),
-        0xD4 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xD4 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.i
-            dest,
-            operand,
-            target: SsaType::NativeInt,
-            overflow_check: true,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::NativeInt, false, true)
         }),
-        0x8A => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x8A => unary_op(uses, def, |dest, operand| {
             // conv.ovf.i.un
-            dest,
-            operand,
-            target: SsaType::NativeInt,
-            overflow_check: true,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::NativeInt, true, true)
         }),
-        0xB4 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xB4 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.u1
-            dest,
-            operand,
-            target: SsaType::U8,
-            overflow_check: true,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::U8, false, true)
         }),
-        0x86 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x86 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.u1.un
-            dest,
-            operand,
-            target: SsaType::U8,
-            overflow_check: true,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::U8, true, true)
         }),
-        0xB6 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xB6 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.u2
-            dest,
-            operand,
-            target: SsaType::U16,
-            overflow_check: true,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::U16, false, true)
         }),
-        0x87 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x87 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.u2.un
-            dest,
-            operand,
-            target: SsaType::U16,
-            overflow_check: true,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::U16, true, true)
         }),
-        0xB8 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xB8 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.u4
-            dest,
-            operand,
-            target: SsaType::U32,
-            overflow_check: true,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::U32, false, true)
         }),
-        0x88 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x88 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.u4.un
-            dest,
-            operand,
-            target: SsaType::U32,
-            overflow_check: true,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::U32, true, true)
         }),
-        0xBA => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xBA => unary_op(uses, def, |dest, operand| {
             // conv.ovf.u8
-            dest,
-            operand,
-            target: SsaType::U64,
-            overflow_check: true,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::U64, false, true)
         }),
-        0x89 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x89 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.u8.un
-            dest,
-            operand,
-            target: SsaType::U64,
-            overflow_check: true,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::U64, true, true)
         }),
-        0xD5 => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0xD5 => unary_op(uses, def, |dest, operand| {
             // conv.ovf.u
-            dest,
-            operand,
-            target: SsaType::NativeUInt,
-            overflow_check: true,
-            unsigned: false,
+            conv_op_for_target(dest, operand, SsaType::NativeUInt, false, true)
         }),
-        0x8B => unary_op(uses, def, |dest, operand| SsaOp::Conv {
+        0x8B => unary_op(uses, def, |dest, operand| {
             // conv.ovf.u.un
-            dest,
-            operand,
-            target: SsaType::NativeUInt,
-            overflow_check: true,
-            unsigned: true,
+            conv_op_for_target(dest, operand, SsaType::NativeUInt, true, true)
         }),
         0x2A => Some(SsaOp::Return {
             // ret
@@ -1848,7 +1717,7 @@ mod tests {
 
         let op = decompose_instruction(&instr, &uses, def, &[], None).unwrap();
 
-        if let SsaOp::Conv {
+        if let SsaOp::IntConv {
             dest,
             operand,
             target,
@@ -1862,7 +1731,7 @@ mod tests {
             assert!(!overflow_check);
             assert!(!unsigned);
         } else {
-            panic!("Expected SsaOp::Conv");
+            panic!("Expected SsaOp::IntConv");
         }
     }
 
@@ -2483,28 +2352,32 @@ mod tests {
             let v1 = SsaVarId::from_index(1);
             let op = decompose_instruction(&instr, &[v0], Some(v1), &[], None);
 
-            if let Ok(SsaOp::Conv {
-                target,
-                overflow_check,
-                unsigned,
-                ..
-            }) = op
-            {
-                assert_eq!(
-                    target, expected_type,
-                    "Type mismatch for opcode {opcode:#x}"
-                );
-                assert_eq!(
-                    overflow_check, expected_ovf,
-                    "Overflow mismatch for opcode {opcode:#x}"
-                );
-                assert_eq!(
-                    unsigned, expected_unsigned,
-                    "Unsigned mismatch for opcode {opcode:#x}"
-                );
-            } else {
-                panic!("Expected SsaOp::Conv for opcode {opcode:#x}");
-            }
+            // conv.i*/u* lower to `IntConv`, conv.r* to `IntToFloat` (which
+            // carries no overflow-check); extract the shared fields from either.
+            let (target, overflow_check, unsigned) = match op {
+                Ok(SsaOp::IntConv {
+                    target,
+                    overflow_check,
+                    unsigned,
+                    ..
+                }) => (target, overflow_check, unsigned),
+                Ok(SsaOp::IntToFloat {
+                    target, unsigned, ..
+                }) => (target, false, unsigned),
+                other => panic!("Expected a conversion op for opcode {opcode:#x}, got {other:?}"),
+            };
+            assert_eq!(
+                target, expected_type,
+                "Type mismatch for opcode {opcode:#x}"
+            );
+            assert_eq!(
+                overflow_check, expected_ovf,
+                "Overflow mismatch for opcode {opcode:#x}"
+            );
+            assert_eq!(
+                unsigned, expected_unsigned,
+                "Unsigned mismatch for opcode {opcode:#x}"
+            );
         }
     }
 
@@ -2529,7 +2402,8 @@ mod tests {
             let v1 = SsaVarId::from_index(1);
             let op = decompose_instruction(&instr, &[v0], Some(v1), &[], None);
 
-            if let Ok(SsaOp::Conv {
+            // All conv.ovf.* opcodes target an integer, so they lower to `IntConv`.
+            if let Ok(SsaOp::IntConv {
                 target,
                 overflow_check,
                 unsigned,
@@ -2549,7 +2423,7 @@ mod tests {
                     "Unsigned mismatch for opcode {opcode:#x}"
                 );
             } else {
-                panic!("Expected SsaOp::Conv for opcode {opcode:#x}");
+                panic!("Expected SsaOp::IntConv for opcode {opcode:#x}");
             }
         }
     }

--- a/dotscope/src/analysis/ssa/mod.rs
+++ b/dotscope/src/analysis/ssa/mod.rs
@@ -93,6 +93,7 @@ mod value;
 // shims that used to mediate via `mod cfg/consts/phi/...` collapsed into
 // the `pub use` block below.
 
+pub(crate) use builder::conv_op_for_target;
 pub use builder::SsaFunctionBuilder;
 pub use converter::SsaConverter;
 pub use exception::{SsaExceptionHandler, SsaExceptionHandlerCilExt};

--- a/dotscope/src/cilassembly/cleanup/analysis.rs
+++ b/dotscope/src/cilassembly/cleanup/analysis.rs
@@ -177,34 +177,47 @@ pub fn find_unreferenced_types(
 
     // Compute which candidates have live external callers
     let mut has_external_caller: HashSet<Token> = HashSet::new();
-
-    for (caller_token, callees) in method_call_graph {
-        // Skip callers that are deleted
-        if deleted_methods.contains(caller_token) {
-            continue;
-        }
-        let Some(caller_type) = method_to_type.get(caller_token).copied() else {
-            continue;
-        };
-        // Skip callers whose type is deleted
-        if deleted_types.contains(&caller_type) {
-            continue;
-        }
-        // Skip callers that are themselves candidates — their edges are
-        // intra-cluster and don't constitute external references
-        let caller_is_candidate = candidates.contains(&caller_type);
-
-        for callee_token in callees {
-            let Some(callee_type) = method_to_type.get(callee_token).copied() else {
+    loop {
+        /* We need to loop here, because if one type has an external reference,
+           that type is no longer a candidate and can reference other candidate types.
+        */
+        let mut changed = false;
+        for (caller_token, callees) in method_call_graph {
+            // Skip callers that are deleted
+            if deleted_methods.contains(caller_token) {
+                continue;
+            }
+            let Some(caller_type) = method_to_type.get(caller_token).copied() else {
                 continue;
             };
-            if caller_type == callee_type {
+            // Skip callers whose type is deleted
+            if deleted_types.contains(&caller_type) {
                 continue;
             }
-            // Only mark as externally referenced if the caller is NOT a candidate
-            if !caller_is_candidate && candidates.contains(&callee_type) {
-                has_external_caller.insert(callee_type);
+            // Skip callers that are themselves candidates — their edges are
+            // intra-cluster and don't constitute external references
+            let caller_is_candidate = candidates.contains(&caller_type);
+
+            for callee_token in callees {
+                let Some(callee_type) = method_to_type.get(callee_token).copied() else {
+                    continue;
+                };
+                if caller_type == callee_type {
+                    continue;
+                }
+                // Only mark as externally referenced if the caller is NOT a candidate
+                if !caller_is_candidate && candidates.contains(&callee_type) {
+                    has_external_caller.insert(callee_type);
+                    candidates.remove(&callee_type);
+                    // Track changes to ensure any types that are no longer candidates are accounted for
+                    changed = true;
+                }
             }
+        }
+
+        // Stop looping once theres no more candidate deletions, or no more candidates.
+        if !changed || candidates.is_empty() {
+            break;
         }
     }
 

--- a/dotscope/src/compiler/codegen/mod.rs
+++ b/dotscope/src/compiler/codegen/mod.rs
@@ -2516,7 +2516,12 @@ impl SsaCodeGenerator {
             // Unary ops consume their operand
             SsaOp::Neg { operand, .. }
             | SsaOp::Not { operand, .. }
-            | SsaOp::Conv { operand, .. }
+            | SsaOp::IntConv { operand, .. }
+            | SsaOp::IntToPtr { operand, .. }
+            | SsaOp::PtrToInt { operand, .. }
+            | SsaOp::IntToFloat { operand, .. }
+            | SsaOp::FloatToInt { operand, .. }
+            | SsaOp::FloatConv { operand, .. }
             | SsaOp::Ckfinite { operand, .. }
                 if *operand == var =>
             {
@@ -3382,7 +3387,13 @@ impl SsaCodeGenerator {
             | SsaOp::Not { .. } => Self::generate_arithmetic_op(encoder, op)?,
 
             // Conversion operations
-            SsaOp::Conv { .. } | SsaOp::Ckfinite { .. } => {
+            SsaOp::IntConv { .. }
+            | SsaOp::IntToPtr { .. }
+            | SsaOp::PtrToInt { .. }
+            | SsaOp::IntToFloat { .. }
+            | SsaOp::FloatToInt { .. }
+            | SsaOp::FloatConv { .. }
+            | SsaOp::Ckfinite { .. } => {
                 Self::generate_conversion_op(encoder, op)?;
             }
 
@@ -3655,15 +3666,39 @@ impl SsaCodeGenerator {
     /// Operand is already on the evaluation stack.
     fn generate_conversion_op(encoder: &mut InstructionEncoder, op: &SsaOp) -> Result<()> {
         match op {
-            SsaOp::Conv {
+            // Integer and float→integer conversions carry both an overflow-check
+            // and a signedness; integer→float carries only signedness; the
+            // pointer and float-width conversions carry neither.
+            SsaOp::IntConv {
+                dest,
+                target,
+                overflow_check,
+                unsigned,
+                ..
+            }
+            | SsaOp::FloatToInt {
                 dest,
                 target,
                 overflow_check,
                 unsigned,
                 ..
             } => {
-                // Operand already on stack
                 emitter::emit_conv(encoder, target, *overflow_check, *unsigned)?;
+                let _ = dest;
+            }
+            SsaOp::IntToFloat {
+                dest,
+                target,
+                unsigned,
+                ..
+            } => {
+                emitter::emit_conv(encoder, target, false, *unsigned)?;
+                let _ = dest;
+            }
+            SsaOp::IntToPtr { dest, target, .. }
+            | SsaOp::PtrToInt { dest, target, .. }
+            | SsaOp::FloatConv { dest, target, .. } => {
+                emitter::emit_conv(encoder, target, false, false)?;
                 let _ = dest;
             }
 
@@ -4179,7 +4214,12 @@ impl SsaCodeGenerator {
             // Unary operations: single operand
             SsaOp::Neg { operand, .. }
             | SsaOp::Not { operand, .. }
-            | SsaOp::Conv { operand, .. }
+            | SsaOp::IntConv { operand, .. }
+            | SsaOp::IntToPtr { operand, .. }
+            | SsaOp::PtrToInt { operand, .. }
+            | SsaOp::IntToFloat { operand, .. }
+            | SsaOp::FloatToInt { operand, .. }
+            | SsaOp::FloatConv { operand, .. }
             | SsaOp::Ckfinite { operand, .. } => vec![*operand],
 
             // Return with value

--- a/dotscope/src/compiler/passes/constants/mod.rs
+++ b/dotscope/src/compiler/passes/constants/mod.rs
@@ -39,9 +39,9 @@ use analyssa::BitSet;
 
 use crate::{
     analysis::{
-        simplify_op, CilTarget, CmpKind, ConstValue, ConstValueCilExt, ConstantPropagation,
-        MethodRef, SccpResult, SimplifyResult, SsaCfg, SsaEvaluator, SsaFunction, SsaOp, SsaType,
-        SsaVarId,
+        conv_op_for_target, simplify_op, CilTarget, CmpKind, ConstValue, ConstValueCilExt,
+        ConstantPropagation, MethodRef, SccpResult, SimplifyResult, SsaCfg, SsaEvaluator,
+        SsaFunction, SsaOp, SsaType, SsaVarId,
     },
     compiler::{
         pass::{ModificationScope, SsaPass},
@@ -391,12 +391,13 @@ impl ConstantPropagationPass {
 
         for (block_idx, block) in ssa.iter_blocks() {
             for (instr_idx, instr) in block.instructions().iter().enumerate() {
-                if let SsaOp::Conv {
+                if let SsaOp::IntConv {
                     dest,
                     operand,
                     target,
                     overflow_check,
                     unsigned,
+                    ..
                 } = instr.op()
                 {
                     if let Some(operand_val) = constants.get(operand) {
@@ -471,12 +472,13 @@ impl ConstantPropagationPass {
         // First pass: collect all Conv definitions and variable types
         for (block_idx, block) in ssa.iter_blocks() {
             for (instr_idx, instr) in block.instructions().iter().enumerate() {
-                if let SsaOp::Conv {
+                if let SsaOp::IntConv {
                     dest,
                     operand,
                     target,
                     overflow_check,
                     unsigned,
+                    ..
                 } = instr.op()
                 {
                     definitions.insert(
@@ -499,12 +501,13 @@ impl ConstantPropagationPass {
 
         for (block_idx, block) in ssa.iter_blocks() {
             for (instr_idx, instr) in block.instructions().iter().enumerate() {
-                if let SsaOp::Conv {
+                if let SsaOp::IntConv {
                     dest,
                     operand,
                     target,
                     overflow_check,
                     unsigned,
+                    ..
                 } = instr.op()
                 {
                     // Skip overflow-checked conversions - these have different semantics
@@ -599,13 +602,13 @@ impl ConstantPropagationPass {
                         if let Some(instr) = block.instructions_mut().get_mut(instr_idx) {
                             let old_op_str = format!("{}", instr.op());
 
-                            instr.set_op(SsaOp::Conv {
+                            instr.set_op(conv_op_for_target(
                                 dest,
-                                operand: new_operand,
-                                target: target.clone(),
-                                overflow_check: false,
+                                new_operand,
+                                target.clone(),
                                 unsigned,
-                            });
+                                false,
+                            ));
 
                             changes
                                 .record(EventKind::ConstantFolded)

--- a/dotscope/src/compiler/passes/constants/tests.rs
+++ b/dotscope/src/compiler/passes/constants/tests.rs
@@ -1027,7 +1027,13 @@ fn test_duplicate_conversion_elimination() {
     // v2 should now be conv.i4(v0), not conv.i4(v1)
     let block = ssa.block(0).unwrap();
     let instr = &block.instructions()[2];
-    if let SsaOp::Conv { operand, .. } = instr.op() {
+    if let SsaOp::IntConv { operand, .. }
+    | SsaOp::IntToPtr { operand, .. }
+    | SsaOp::PtrToInt { operand, .. }
+    | SsaOp::IntToFloat { operand, .. }
+    | SsaOp::FloatToInt { operand, .. }
+    | SsaOp::FloatConv { operand, .. } = instr.op()
+    {
         assert_eq!(
             *operand, v0,
             "Duplicate conversion should use original operand"
@@ -1067,14 +1073,14 @@ fn test_widening_chain_elimination() {
     // v2 should now be conv.u8(v0), not conv.u8(v1)
     let block = ssa.block(0).unwrap();
     let instr = &block.instructions()[2];
-    if let SsaOp::Conv {
+    if let SsaOp::IntConv {
         operand, target, ..
     } = instr.op()
     {
         assert_eq!(*operand, v0, "Widening chain should use original operand");
         assert_eq!(*target, SsaType::U64);
     } else {
-        panic!("Expected Conv instruction");
+        panic!("Expected IntConv instruction");
     }
 }
 
@@ -1107,7 +1113,7 @@ fn test_overflow_checked_conversion_not_eliminated() {
     // v2 should still be conv.ovf.i4(v1), not modified
     let block = ssa.block(0).unwrap();
     let instr = &block.instructions()[2];
-    if let SsaOp::Conv {
+    if let SsaOp::IntConv {
         operand,
         overflow_check,
         ..
@@ -1152,7 +1158,13 @@ fn test_float_widening_not_eliminated() {
     // v2 should still use v1, not v0
     let block = ssa.block(0).unwrap();
     let instr = &block.instructions()[2];
-    if let SsaOp::Conv { operand, .. } = instr.op() {
+    if let SsaOp::IntConv { operand, .. }
+    | SsaOp::IntToPtr { operand, .. }
+    | SsaOp::PtrToInt { operand, .. }
+    | SsaOp::IntToFloat { operand, .. }
+    | SsaOp::FloatToInt { operand, .. }
+    | SsaOp::FloatConv { operand, .. } = instr.op()
+    {
         assert_eq!(
             *operand, v1,
             "Float conversion chain should not be simplified"

--- a/dotscope/src/deobfuscation/passes/unflattening/tracer/helpers.rs
+++ b/dotscope/src/deobfuscation/passes/unflattening/tracer/helpers.rs
@@ -272,7 +272,14 @@ pub fn const_producer_target(block: &SsaBlock) -> Option<usize> {
     if !non_term.iter().all(|i| {
         matches!(
             i.op(),
-            SsaOp::Const { .. } | SsaOp::Copy { .. } | SsaOp::Conv { .. }
+            SsaOp::Const { .. }
+                | SsaOp::Copy { .. }
+                | SsaOp::IntConv { .. }
+                | SsaOp::IntToPtr { .. }
+                | SsaOp::PtrToInt { .. }
+                | SsaOp::IntToFloat { .. }
+                | SsaOp::FloatToInt { .. }
+                | SsaOp::FloatConv { .. }
         )
     }) {
         return None;

--- a/dotscope/src/deobfuscation/renamer/features.rs
+++ b/dotscope/src/deobfuscation/renamer/features.rs
@@ -211,7 +211,12 @@ pub fn build_opcode_profile(ssa: &SsaFunction) -> OpcodeProfile {
             }
 
             // Conversion
-            SsaOp::Conv { .. } => {
+            SsaOp::IntConv { .. }
+            | SsaOp::IntToPtr { .. }
+            | SsaOp::PtrToInt { .. }
+            | SsaOp::IntToFloat { .. }
+            | SsaOp::FloatToInt { .. }
+            | SsaOp::FloatConv { .. } => {
                 profile.conversion = profile.conversion.saturating_add(1);
             }
 

--- a/dotscope/src/deobfuscation/renamer/phases.rs
+++ b/dotscope/src/deobfuscation/renamer/phases.rs
@@ -317,11 +317,38 @@ pub fn build_call_site_skeleton(ssa: &SsaFunction, assembly: &CilObject) -> Opti
             }
 
             // Conversion
-            SsaOp::Conv {
+            SsaOp::IntConv {
                 dest,
                 operand,
                 target,
                 ..
+            }
+            | SsaOp::IntToPtr {
+                dest,
+                operand,
+                target,
+            }
+            | SsaOp::PtrToInt {
+                dest,
+                operand,
+                target,
+            }
+            | SsaOp::IntToFloat {
+                dest,
+                operand,
+                target,
+                ..
+            }
+            | SsaOp::FloatToInt {
+                dest,
+                operand,
+                target,
+                ..
+            }
+            | SsaOp::FloatConv {
+                dest,
+                operand,
+                target,
             } => {
                 lines.push(format!(
                     "    var_{} = ({target})var_{};",
@@ -753,7 +780,12 @@ fn classify_op_into_profile(op: &SsaOp, profile: &mut OpcodeProfile) {
         | SsaOp::BranchCmp { .. } => {
             profile.comparison = profile.comparison.saturating_add(1);
         }
-        SsaOp::Conv { .. } => {
+        SsaOp::IntConv { .. }
+        | SsaOp::IntToPtr { .. }
+        | SsaOp::PtrToInt { .. }
+        | SsaOp::IntToFloat { .. }
+        | SsaOp::FloatToInt { .. }
+        | SsaOp::FloatConv { .. } => {
             profile.conversion = profile.conversion.saturating_add(1);
         }
         _ => {}

--- a/dotscope/src/deobfuscation/techniques/confuserex/statemachine.rs
+++ b/dotscope/src/deobfuscation/techniques/confuserex/statemachine.rs
@@ -267,7 +267,14 @@ impl StateMachineProvider for ConfuserExStateMachine {
                 let arg_def = ssa.get_definition(first_arg);
                 let xor_def = match arg_def {
                     Some(SsaOp::Xor { .. }) => arg_def,
-                    Some(SsaOp::Conv { operand, .. }) => ssa.get_definition(*operand),
+                    Some(
+                        SsaOp::IntConv { operand, .. }
+                        | SsaOp::IntToPtr { operand, .. }
+                        | SsaOp::PtrToInt { operand, .. }
+                        | SsaOp::IntToFloat { operand, .. }
+                        | SsaOp::FloatToInt { operand, .. }
+                        | SsaOp::FloatConv { operand, .. },
+                    ) => ssa.get_definition(*operand),
                     _ => None,
                 };
                 let Some(SsaOp::Xor { left, right, .. }) = xor_def else {
@@ -734,7 +741,12 @@ fn trace_to_arithmetic_op(ssa: &SsaFunction, start_var: SsaVarId) -> Option<Stat
             SsaOp::Or { .. } => return Some(StateSlotOperation::or()),
 
             // Conversion - add operand to worklist to trace through
-            SsaOp::Conv { operand, .. } => {
+            SsaOp::IntConv { operand, .. }
+            | SsaOp::IntToPtr { operand, .. }
+            | SsaOp::PtrToInt { operand, .. }
+            | SsaOp::IntToFloat { operand, .. }
+            | SsaOp::FloatToInt { operand, .. }
+            | SsaOp::FloatConv { operand, .. } => {
                 worklist.push(*operand);
             }
 

--- a/dotscope/src/metadata/exports/container.rs
+++ b/dotscope/src/metadata/exports/container.rs
@@ -801,7 +801,7 @@ mod tests {
         assert_eq!(results.len(), 1);
 
         let ExportEntry::Native(native_ref) = &results[0] else {
-            panic!("Expected Native export entry, got {:?}", &results[0]);
+            panic!("Expected Native export entry, got {:?}", results[0]);
         };
         assert_eq!(native_ref.ordinal, 1);
         assert_eq!(native_ref.name, Some("MyExport".to_string()));

--- a/dotscope/src/metadata/loader/mod.rs
+++ b/dotscope/src/metadata/loader/mod.rs
@@ -559,7 +559,7 @@ pub(crate) fn execute_loaders_in_parallel(
                         {
                             return Err(Error::TypeError(format!(
                                 "Failed to redirect TypeRef {}",
-                                &type_rc.fullname()
+                                type_rc.fullname()
                             )));
                         }
                     }

--- a/dotscope/src/metadata/security/permissionset.rs
+++ b/dotscope/src/metadata/security/permissionset.rs
@@ -697,10 +697,8 @@ impl PermissionSet {
                         in_permission_set = true;
                     }
                     b"IPermission" if in_permission_set => {
-                        match Self::parse_permission_from_xml_attributes(e.attributes()) {
-                            Ok(permission) => permissions.push(permission),
-                            Err(e) => return Err(e),
-                        }
+                        permissions
+                            .push(Self::parse_permission_from_xml_attributes(e.attributes())?);
                     }
                     _ => {}
                 },
@@ -708,10 +706,7 @@ impl PermissionSet {
                 Ok(Event::Empty(ref e))
                     if e.name().as_ref() == b"IPermission" && in_permission_set =>
                 {
-                    match Self::parse_permission_from_xml_attributes(e.attributes()) {
-                        Ok(permission) => permissions.push(permission),
-                        Err(e) => return Err(e),
-                    }
+                    permissions.push(Self::parse_permission_from_xml_attributes(e.attributes())?);
                 }
                 Ok(Event::End(ref e)) if e.name().as_ref() == b"PermissionSet" => {
                     in_permission_set = false;

--- a/dotscope/tests/modify_roundtrips_method.rs
+++ b/dotscope/tests/modify_roundtrips_method.rs
@@ -294,7 +294,7 @@ fn verify_injected_method_instructions(
     } else {
         panic!(
             "ldstr operand should be a token, found: {:?}",
-            &instructions[0].operand
+            instructions[0].operand
         );
     }
 
@@ -309,7 +309,7 @@ fn verify_injected_method_instructions(
     } else {
         panic!(
             "call operand should be a token, found: {:?}",
-            &instructions[1].operand
+            instructions[1].operand
         );
     }
 
@@ -319,7 +319,7 @@ fn verify_injected_method_instructions(
     } else {
         panic!(
             "ret instruction should have no operand, found: {:?}",
-            &instructions[2].operand
+            instructions[2].operand
         );
     }
 

--- a/dotscope/tests/ssa.rs
+++ b/dotscope/tests/ssa.rs
@@ -590,14 +590,17 @@ fn test_ssa_conversion_operations() -> Result<()> {
 
     assert_eq!(ssa.block_count(), 1);
 
-    // Check for Conv operations
+    // `conv.i8`/`conv.i4` are integer→integer conversions, which lower to
+    // `IntConv`: analyssa 0.3 split the old `Conv` into a domain-typed family
+    // (see `conv_op_for_target`), so only a float or pointer target produces
+    // `IntToFloat`/`IntToPtr`.
     let block = ssa.block(0).unwrap();
     let conv_count = block
         .instructions()
         .iter()
-        .filter(|instr| matches!(instr.op(), SsaOp::Conv { .. }))
+        .filter(|instr| matches!(instr.op(), SsaOp::IntConv { .. }))
         .count();
-    assert!(conv_count >= 2, "Expected at least 2 Conv operations");
+    assert!(conv_count >= 2, "Expected at least 2 IntConv operations");
 
     Ok(())
 }
@@ -1852,13 +1855,14 @@ fn test_ssa_conv_unsigned() -> Result<()> {
 
     let ssa = ssa_from_asm(asm, 1, 0)?;
 
-    // Check for unsigned Conv operation
+    // `conv.u4` targets uint32 — an integer→integer conversion, so it lowers to
+    // `IntConv`, which retains the opcode's `unsigned` flag.
     let block = ssa.block(0).unwrap();
     let has_conv_u = block
         .instructions()
         .iter()
-        .any(|instr| matches!(instr.op(), SsaOp::Conv { unsigned: true, .. }));
-    assert!(has_conv_u, "Expected unsigned Conv operation");
+        .any(|instr| matches!(instr.op(), SsaOp::IntConv { unsigned: true, .. }));
+    assert!(has_conv_u, "Expected unsigned IntConv operation");
 
     Ok(())
 }


### PR DESCRIPTION
Currently, my understanding of the unreferenced type finder in dotscope/src/cilassembly/cleanup/analysis.rs find_unreferenced_types() is:
Searches for candidate types, with the following criteria:
- Is not the <Module> type, is not public
- Is not an entry point type
- is not already tagged for deletion
- Has at least one non .cctor method
Each candidate is checked for a few criteria to determine if it is externally called:
- Not already a deleted method
- Has a caller type
- A caller for the type is not a candidate, but the callee type is

This logic seems to work well, however it does not account for candidate types that contain methods which reference other candidate types. Because the caller is a candidate, these types cannot be inserted into has_external_caller. This causes potential issues in situations where a candidate type is determined to be externally referenced, and thus no longer a candidate, but other candidate types that are still present in candidates which are only referenced by other candidate types which may be referenced by an entrypoint type are still considered candidates for removal. 

Any confuserex obfuscated binary will trip this issue, as it contains multiple classes under the <Module> definition that are not public and thus considered candidates for removal, but are only referenced by other candidates. The end result is a significant amount of valid code being considered dead by later parts of the pipeline and most of the executable's constant protection infrastructure methods being removed, despite the executable not being successfully deobfuscated by any other stage, and thus still present in the executable.

I propose adding a while loop to the code, while also removing any type from candidates that is determined to be referenced by an external type. The while loop can track changes in candidates, and once there is a pass with no change in candidates or all candidates are determined valid, execution can proceed. 