### PR TITLE
ci: grant the CLI build job permission to upload release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,13 @@ jobs:
     name: Build CLI (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     needs: [version, test]
+
+    # Needed to attach the built binaries to the release. The default
+    # GITHUB_TOKEN permission is read-only, which makes the upload fail with
+    # "Resource not accessible by integration".
+    permissions:
+      contents: write
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The v0.8.5 release published to crates.io successfully, but all three `Build CLI` jobs failed at the upload step with `HTTP 403: Resource not accessible by integration`, so no binaries are attached to that release.

The job uploads through `GITHUB_TOKEN` but declares no `permissions` block, so it inherits the default workflow permission — which is read-only here. Granting `contents: write` on that job alone keeps the elevated permission scoped to the step that needs it, rather than raising the default for every workflow.